### PR TITLE
fixes missing loader for scss in production config

### DIFF
--- a/client/config/webpack.config.prod.js
+++ b/client/config/webpack.config.prod.js
@@ -170,6 +170,20 @@ module.exports = {
               ),
             ),
           },
+          {
+            test: /\.scss$/,
+            use: [
+              require.resolve('style-loader'),
+              {
+                loader: require.resolve('css-loader'),
+                options: {sourceMap: true},
+              },
+              {
+                loader: require.resolve('sass-loader'),
+                options: {sourceMap: true},
+              },
+            ],
+          },
           // The notation here is somewhat confusing.
           // "postcss" loader applies autoprefixer to our CSS.
           // "css" loader resolves paths in CSS and adds assets as dependencies.

--- a/client/config/webpack.config.prod.js
+++ b/client/config/webpack.config.prod.js
@@ -150,27 +150,6 @@ module.exports = {
             },
           },
           {
-            test: /bootstrap\.scss$/,
-            loader: ExtractTextPlugin.extract(
-              Object.assign(
-                {
-                  fallback: require.resolve('style-loader'),
-                  use: [
-                    {
-                      loader: require.resolve('css-loader'),
-                      options: {sourceMap: true, minimize: true},
-                    },
-                    {
-                      loader: require.resolve('sass-loader'),
-                      options: {sourceMap: true},
-                    },
-                  ],
-                },
-                extractTextPluginOptions,
-              ),
-            ),
-          },
-          {
             test: /\.scss$/,
             use: [
               require.resolve('style-loader'),


### PR DESCRIPTION
After some investigation, looks like this change:

https://github.com/reversim/reversim-summit-2020/commit/041bb212944c0b74bea26fda68801705bc6c9add#diff-756d79f1a0855e43492459219858a1ecL178

Made dev work, but production never worked correctly because it remained the same (loading *only* bootstrap.scss).

I've aligned scss loading in prod to be the same as dev loading scss.
